### PR TITLE
Update documentation to reflect security hardening changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,11 @@ This is a client-server system for monitoring Govee H5075 temperature and humidi
 ### Building
 
 ```bash
-# Build server
-cd server && go build -o govee-server govee-server.go
+# Build server (includes all source files)
+cd server && go build -o govee-server .
 
 # Build client
-cd client && go build -o govee-client govee-client.go
+cd client && go build -o govee-client .
 ```
 
 ### Running Locally
@@ -89,6 +89,8 @@ make benchmark
 │   └── docker-compose.yaml
 ├── server/
 │   ├── govee-server.go      # HTTP server + storage manager
+│   ├── storage.go           # SQLite storage backend
+│   ├── migrate.go           # JSON-to-SQLite migration tool
 │   ├── Dockerfile
 │   └── docker-compose.yaml
 ├── static/
@@ -111,11 +113,14 @@ make benchmark
 - Supports temperature/humidity offset calibration
 
 **server/govee-server.go**
-- Single-file HTTP server (no external web framework)
+- HTTP server (no external web framework)
 - In-memory storage with periodic disk persistence
 - Time-based data partitioning (daily/weekly/monthly directories)
 - Automatic data retention and compression
 - API key authentication with admin/client-specific/default keys
+- Rate limiting with configurable trusted proxy support
+- Input validation (device names, addresses, client IDs)
+- Gzip compression middleware
 - Serves static dashboard files
 
 **Data Storage**
@@ -140,7 +145,7 @@ API keys are stored in `data/auth.json` and validated via `X-API-Key` header.
 - `GET /devices` - List all devices with latest status
 - `GET /clients` - List all connected clients
 - `GET /stats?device=<addr>` - Get statistics for device
-- `GET /dashboard/data` - Get all data for dashboard
+- `GET /dashboard/data` - Get all data for dashboard (no auth required)
 - `GET /api/keys` - List API keys (admin only)
 - `POST /api/keys` - Create API key (admin only)
 - `DELETE /api/keys?key=<key>` - Delete API key (admin only)
@@ -207,6 +212,7 @@ See README.md for complete flag reference. Key flags:
 - `-partition-interval` (default 720h)
 - `-retention` (default 0 = unlimited)
 - `-compress` (default true)
+- `-trusted-proxies` (CIDR ranges of trusted reverse proxies, e.g. `10.0.0.0/8,172.16.0.0/12`)
 
 **Client:**
 - `-server` (default http://localhost:8080/readings)

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -318,12 +318,11 @@ curl http://localhost:8080/health | jq '.goroutines'
 
 ## Documentation
 
-- **README.md** - Complete system documentation
-- **docs/OPTIMIZATION_GUIDE.md** - Performance tuning and upgrades
-- **docs/IMPLEMENTATION_SUMMARY.md** - Technical details
-- **docs/authentication-guide.md** - Security setup
-- **CODE_REVIEW.md** - Security audit
-- **FIXES_APPLIED.md** - Changelog
+- **[README.md](README.md)** - Complete system documentation
+- **[docs/authentication-guide.md](docs/authentication-guide.md)** - Security setup
+- **[docs/data-storage-guide.md](docs/data-storage-guide.md)** - Storage, retention, partitioning
+- **[docs/metrics-guide.md](docs/metrics-guide.md)** - Enhanced environmental metrics
+- **[openapi/openapi.yaml](openapi/openapi.yaml)** - OpenAPI v3 specification
 
 ---
 
@@ -365,4 +364,4 @@ docker-compose pull                     # Update images
 
 **You're all set! Your Govee monitoring system is now running. 🎉**
 
-For advanced configuration, see [README.md](README.md) and [docs/OPTIMIZATION_GUIDE.md](docs/OPTIMIZATION_GUIDE.md).
+For advanced configuration, see [README.md](README.md) and [docs/data-storage-guide.md](docs/data-storage-guide.md).

--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ I might add support for some other models and modes of operation in time.
 ## 🚀 What's New in v2.0
 
 - **10-100x Faster Queries** - SQLite storage backend for the server (optional), with indexed queries. Replaces munging potentially thousands of JSON files
-- **Enhanced Security** - XSS fixes, security headers, proper input validation
+- **Enhanced Security** - XSS fixes, security headers, proper input validation, rate limiting, trusted proxy support
 - **Dashboard** - Faster dashboard loads with configurable cache
 - **Improved Testing** - 105 unit tests, benchmarks
-- **CI/CD Pipeline** - Automated testing, linting, security scanning
 - **Better Monitoring** - Enhanced health checks with detailed system stats
 
 ## 📖 Quick Start
@@ -88,12 +87,12 @@ The system consists of the following components:
 
 #### Server Setup
 
-1. Install Go 1.18 or later
+1. Install Go 1.22 or later
 2. Clone the repository
 3. Navigate to the server directory
 4. Build the server:
    ```bash
-   go build -o govee-server govee-server.go
+   go build -o govee-server .
    ```
 5. Run the server:
    ```bash
@@ -102,12 +101,12 @@ The system consists of the following components:
 
 #### Client Setup
 
-1. Install Go 1.18 or later and Bluetooth development libraries
+1. Install Go 1.22 or later and Bluetooth development libraries
 2. Clone the repository
 3. Navigate to the client directory
 4. Build the client:
    ```bash
-   go build -o govee-client govee-client.go
+   go build -o govee-client .
    ```
 5. Run the client:
    ```bash
@@ -212,6 +211,7 @@ The server accepts the following command-line arguments:
 | `-partition-interval` | 720h (30 days) | Interval for new data partitions |
 | `-retention` | 0 (unlimited) | How long to keep data (e.g., 8760h for 1 year) |
 | `-compress` | true | Compress older partitions to save space |
+| `-trusted-proxies` | "" | Comma-separated CIDR ranges of trusted reverse proxies (e.g., `10.0.0.0/8`) |
 
 ## Data Storage and Retention
 
@@ -331,7 +331,7 @@ The server provides the following API endpoints:
 | `/devices` | GET | Get all devices and their latest status | Yes |
 | `/clients` | GET | Get all clients and their status | Yes |
 | `/stats?device=<addr>` | GET | Get statistics for a specific device | Yes |
-| `/dashboard/data` | GET | Get all data needed for the dashboard | Yes |
+| `/dashboard/data` | GET | Get all data needed for the dashboard | No |
 | `/api/keys` | GET/POST/DELETE | Manage API keys | Admin key only |
 | `/health` | GET | Health check endpoint | No |
 

--- a/docs/authentication-guide.md
+++ b/docs/authentication-guide.md
@@ -12,15 +12,19 @@ The system implements multiple layers of security:
 2. **HTTPS/TLS Encryption** - Encrypts all data in transit between clients and the server
 3. **Input Validation** - Prevents XSS, path traversal, and injection attacks (v2.0)
 4. **Security Headers** - Comprehensive HTTP security headers (v2.0)
-5. **Rate Limiting** - Prevents abuse and DoS attacks
+5. **Rate Limiting** - Per-IP rate limiting to prevent abuse and DoS attacks
+6. **Trusted Proxy Support** - Configurable trusted proxy CIDRs for correct client IP extraction behind reverse proxies
 
 For maximum security, all features should be enabled and properly configured.
 
 ### New in v2.0
 
 - **Cryptographically Secure API Keys**: Generated using `crypto/rand` for unpredictability
-- **XSS Prevention**: Device names and inputs are validated and sanitized
+- **XSS Prevention**: Device names, client IDs, and all inputs are validated and sanitized
+- **Client ID Validation**: Client IDs must match `^[a-zA-Z0-9_\-\.]+$` (max 100 chars)
 - **Security Headers**: CSP, HSTS, X-Frame-Options, and more
+- **Trusted Proxy Support**: Only trusts `X-Forwarded-For` from configured proxy CIDRs (`-trusted-proxies` flag)
+- **Request Body Limits**: 1MB maximum request body size to prevent resource exhaustion
 - **Enhanced Health Checks**: Monitor security status via `/health` endpoint
 - **Audit Capabilities**: Better logging for security events
 
@@ -255,6 +259,27 @@ services:
    - Check firewall rules for HTTPS port
    - Try using curl with `-k` to bypass verification for testing
 
+## Trusted Proxy Configuration
+
+When running behind a reverse proxy (e.g., nginx, Caddy, Traefik), the server needs to know which proxies to trust for extracting real client IPs from `X-Forwarded-For` headers.
+
+**Without trusted proxies configured**, the server ignores `X-Forwarded-For` entirely and uses the direct connection IP for rate limiting. This is the safe default.
+
+**To enable trusted proxy support:**
+
+```bash
+# Trust a single proxy
+./govee-server -trusted-proxies=10.0.0.1/32
+
+# Trust a subnet
+./govee-server -trusted-proxies=10.0.0.0/8
+
+# Trust multiple ranges (comma-separated CIDRs)
+./govee-server -trusted-proxies=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+```
+
+**Important:** Only configure CIDRs for proxies you control. Trusting arbitrary IPs allows attackers to spoof their source IP via the `X-Forwarded-For` header, bypassing rate limits.
+
 ## Security Best Practices
 
 1. **Use both authentication and HTTPS** for defense in depth
@@ -276,7 +301,7 @@ services:
 | `/devices` | Yes | Get device information |
 | `/clients` | Yes | Get client information |
 | `/stats` | Yes | Get statistics |
-| `/dashboard/data` | Yes | Dashboard data |
+| `/dashboard/data` | No | Dashboard data (read-only, public) |
 | `/api/keys` | Admin only | Manage API keys |
 | `/health` | No | Health check endpoint |
 | `/` | No | Static dashboard files |

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -168,7 +168,6 @@ This will display all enhanced metrics (dew point, absolute humidity, steam pres
 
 - **Migrate to SQLite**: Get 10-100x faster queries (see [Data Storage Guide](data-storage-guide.md))
 - **Enable HTTPS**: Secure your deployment (see [Authentication Guide](authentication-guide.md))
-- **Set up CI/CD**: Automated testing and deployment (see [OPTIMIZATION_GUIDE.md](OPTIMIZATION_GUIDE.md))
 - **Add more clients**: Monitor different areas with multiple client instances
 - **Configure InfluxDB + Grafana**: Advanced data visualization and alerting
 - **Optimize Performance**: Dashboard caching and compression are enabled by default
@@ -179,4 +178,4 @@ This will display all enhanced metrics (dew point, absolute humidity, steam pres
 - **[QUICKSTART.md](../QUICKSTART.md)** - Fast 5-minute setup
 - **[docs/authentication-guide.md](authentication-guide.md)** - Security setup
 - **[docs/data-storage-guide.md](data-storage-guide.md)** - Storage backends and migration
-- **[docs/OPTIMIZATION_GUIDE.md](OPTIMIZATION_GUIDE.md)** - v2.0 performance guide
+- **[docs/metrics-guide.md](metrics-guide.md)** - Enhanced environmental metrics

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -178,9 +178,8 @@ paths:
   /dashboard/data:
     get:
       summary: Get all data needed for the dashboard
-      description: Retrieves a combined dataset for the dashboard UI, including devices, clients, and recent readings
-      security:
-        - ApiKeyAuth: []
+      description: Retrieves a combined dataset for the dashboard UI, including devices, clients, and recent readings. No authentication required as this serves the public dashboard.
+      security: []  # No authentication required - serves public dashboard
       responses:
         '200':
           description: Successful response
@@ -188,13 +187,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DashboardData'
-        '401':
-          description: Unauthorized - API key missing or invalid
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-                
+
   /api/keys:
     get:
       summary: List all API keys
@@ -236,7 +229,9 @@ paths:
               properties:
                 client_id:
                   type: string
-                  description: Client ID to associate with the new API key
+                  description: Client ID to associate with the new API key. Must match pattern [a-zA-Z0-9_\-.]+ (max 100 chars).
+                  pattern: "^[a-zA-Z0-9_\\-.]+$"
+                  maxLength: 100
                   example: "client-kitchen"
       responses:
         '201':
@@ -416,9 +411,11 @@ components:
           example: "2023-04-13T15:30:45Z"
         client_id:
           type: string
-          description: ID of the client that sent the reading
+          description: ID of the client that sent the reading. Must match pattern [a-zA-Z0-9_\-.]+ (max 100 chars).
+          pattern: "^[a-zA-Z0-9_\\-.]+$"
+          maxLength: 100
           example: "client-livingroom"
-          
+
     DeviceStatus:
       type: object
       properties:


### PR DESCRIPTION
- README.md: Remove CI/CD pipeline bullet (workflow removed), fix Go version from 1.18 to 1.22 in manual install steps, fix build commands to use `go build .` instead of single-file, add -trusted-proxies flag to server config table, mark /dashboard/data as no auth required
- CLAUDE.md: Fix build commands, add storage.go/migrate.go to project structure, document -trusted-proxies flag, note /dashboard/data is public, update server component description with new security features
- docs/authentication-guide.md: Add trusted proxy configuration section, document client ID validation rules and pattern, update endpoint security table for /dashboard/data, add request body limits to v2.0 feature list
- openapi/openapi.yaml: Remove auth requirement from /dashboard/data, add pattern and maxLength constraints to client_id fields
- QUICKSTART.md: Fix broken references to non-existent docs (OPTIMIZATION_GUIDE.md, IMPLEMENTATION_SUMMARY.md, CODE_REVIEW.md, FIXES_APPLIED.md) with actual documentation files
- docs/quick-start-guide.md: Remove reference to non-existent OPTIMIZATION_GUIDE.md, fix documentation links

https://claude.ai/code/session_01XcvxnmTmpi6E2xErQ8yv5n