### PR TITLE
Add device friendly name aliases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,9 @@ API keys are stored in `data/auth.json` and validated via `X-API-Key` header.
 - `GET /api/keys` - List API keys (admin only)
 - `POST /api/keys` - Create API key (admin only)
 - `DELETE /api/keys?key=<key>` - Delete API key (admin only)
+- `GET /api/aliases` - List device aliases (requires API key)
+- `PUT /api/aliases` - Set device alias (requires API key)
+- `DELETE /api/aliases?device=<addr>` - Remove device alias (requires API key)
 - `GET /health` - Health check (no auth)
 
 Full API specification: `openapi/openapi.yaml`

--- a/README.md
+++ b/README.md
@@ -320,6 +320,33 @@ Header: X-API-Key: <admin_key>
 
 For more details, see the [Authentication Guide](docs/authentication-guide.md).
 
+## Device Aliases
+
+You can assign friendly names to devices for easier identification. Aliases appear in all API responses and the dashboard alongside the hardware device name.
+
+### Set a device alias
+
+```bash
+curl -X PUT -H "X-API-Key: YOUR_API_KEY" -H "Content-Type: application/json" \
+  -d '{"device_addr": "A4C13825A1E3", "display_name": "Kitchen Temperature"}' \
+  http://localhost:8080/api/aliases
+```
+
+### List all aliases
+
+```bash
+curl -H "X-API-Key: YOUR_API_KEY" http://localhost:8080/api/aliases
+```
+
+### Remove an alias
+
+```bash
+curl -X DELETE -H "X-API-Key: YOUR_API_KEY" \
+  "http://localhost:8080/api/aliases?device=A4C13825A1E3"
+```
+
+When an alias is set, a `display_name` field appears in device and reading responses. The dashboard will show the alias instead of the hardware name (e.g., "Kitchen Temperature" instead of "GVH5075_8F19").
+
 ## API Endpoints
 
 The server provides the following API endpoints:
@@ -333,6 +360,7 @@ The server provides the following API endpoints:
 | `/stats?device=<addr>` | GET | Get statistics for a specific device | Yes |
 | `/dashboard/data` | GET | Get all data needed for the dashboard | No |
 | `/api/keys` | GET/POST/DELETE | Manage API keys | Admin key only |
+| `/api/aliases` | GET/PUT/DELETE | Manage device friendly names | Yes |
 | `/health` | GET | Health check endpoint | No |
 
 ## Dashboard

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -302,6 +302,114 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
                 
+  /api/aliases:
+    get:
+      summary: List device aliases
+      description: Get all device friendly name aliases, or a specific one by device address
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: device
+          in: query
+          description: Device MAC address (optional, omit to list all)
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                example:
+                  "A4C13825A1E3": "Kitchen Temperature"
+                  "A4C13826B2F4": "Living Room"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    put:
+      summary: Set a device alias
+      description: Assign or update a friendly name for a device
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - device_addr
+                - display_name
+              properties:
+                device_addr:
+                  type: string
+                  description: Device MAC address
+                  example: "A4C13825A1E3"
+                display_name:
+                  type: string
+                  description: Friendly name for the device (alphanumeric, spaces, hyphens, underscores, max 100 chars)
+                  example: "Kitchen Temperature"
+      responses:
+        '200':
+          description: Alias set successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  device_addr:
+                    type: string
+                  display_name:
+                    type: string
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    delete:
+      summary: Remove a device alias
+      description: Delete the friendly name for a device
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: device
+          in: query
+          description: Device MAC address
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Alias deleted
+        '404':
+          description: No alias set for device
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /health:
     get:
       summary: Health check endpoint
@@ -345,12 +453,16 @@ components:
       properties:
         device_name:
           type: string
-          description: Name of the Govee device
+          description: Name of the Govee device (hardware name from BLE)
           example: "GVH5075_1234"
         device_addr:
           type: string
           description: MAC address of the device
           example: "A4:C1:38:25:A1:E3"
+        display_name:
+          type: string
+          description: User-assigned friendly name (only present if alias is set)
+          example: "Kitchen Temperature"
         temp_c:
           type: number
           format: float
@@ -421,12 +533,16 @@ components:
       properties:
         device_name:
           type: string
-          description: Name of the Govee device
+          description: Name of the Govee device (hardware name from BLE)
           example: "GVH5075_1234"
         device_addr:
           type: string
           description: MAC address of the device
           example: "A4:C1:38:25:A1:E3"
+        display_name:
+          type: string
+          description: User-assigned friendly name (only present if alias is set)
+          example: "Kitchen Temperature"
         temp_c:
           type: number
           format: float

--- a/server/govee-server.go
+++ b/server/govee-server.go
@@ -31,6 +31,7 @@ import (
 type Reading struct {
 	DeviceName     string    `json:"device_name"`
 	DeviceAddr     string    `json:"device_addr"`
+	DisplayName    string    `json:"display_name,omitempty"`
 	TempC          float64   `json:"temp_c"`
 	TempF          float64   `json:"temp_f"`
 	TempOffset     float64   `json:"temp_offset"`
@@ -50,6 +51,7 @@ type Reading struct {
 type DeviceStatus struct {
 	DeviceName     string    `json:"device_name"`
 	DeviceAddr     string    `json:"device_addr"`
+	DisplayName    string    `json:"display_name,omitempty"`
 	TempC          float64   `json:"temp_c"`
 	TempF          float64   `json:"temp_f"`
 	TempOffset     float64   `json:"temp_offset"`
@@ -154,6 +156,8 @@ type Server struct {
 	clients map[string]*ClientStatus
 	// Stores readings for a device
 	readings map[string][]Reading
+	// Maps device address to user-assigned friendly name
+	deviceAliases map[string]string
 	// Mutex for thread safety
 	mu sync.RWMutex
 	// File logger
@@ -720,6 +724,7 @@ func NewServer(config *Config, auth *AuthConfig, storageManager *StorageManager)
 		devices:        make(map[string]*DeviceStatus),
 		clients:        make(map[string]*ClientStatus),
 		readings:       make(map[string][]Reading),
+		deviceAliases:  make(map[string]string),
 		config:         config,
 		auth:           auth,
 		storageManager: storageManager,
@@ -804,6 +809,10 @@ func (s *Server) saveData() {
 		}
 		authCopy = &ac
 	}
+	aliasesCopy := make(map[string]string, len(s.deviceAliases))
+	for k, v := range s.deviceAliases {
+		aliasesCopy[k] = v
+	}
 	s.mu.RUnlock()
 
 	// Now perform all I/O operations without holding the lock
@@ -836,6 +845,18 @@ func (s *Server) saveData() {
 		} else {
 			if err := os.WriteFile(fmt.Sprintf("%s/auth.json", s.config.StorageDir), authData, 0600); err != nil {
 				log.Printf("Failed to save auth data: %v", err)
+			}
+		}
+	}
+
+	// Save device aliases
+	if len(aliasesCopy) > 0 {
+		aliasData, err := json.MarshalIndent(aliasesCopy, "", "  ")
+		if err != nil {
+			log.Printf("Failed to marshal device aliases: %v", err)
+		} else {
+			if err := os.WriteFile(fmt.Sprintf("%s/aliases.json", s.config.StorageDir), aliasData, 0644); err != nil {
+				log.Printf("Failed to save device aliases: %v", err)
 			}
 		}
 	}
@@ -887,6 +908,16 @@ func (s *Server) loadData() {
 				s.auth.APIKeys = loadedAuth.APIKeys
 				log.Printf("Loaded %d API keys from storage", len(s.auth.APIKeys))
 			}
+		}
+	}
+
+	// Load device aliases
+	aliasData, err := os.ReadFile(fmt.Sprintf("%s/aliases.json", s.config.StorageDir))
+	if err == nil {
+		if err := json.Unmarshal(aliasData, &s.deviceAliases); err != nil {
+			log.Printf("Failed to unmarshal device aliases: %v", err)
+		} else {
+			log.Printf("Loaded %d device aliases from storage", len(s.deviceAliases))
 		}
 	}
 
@@ -1040,7 +1071,11 @@ func (s *Server) getDevices() []*DeviceStatus {
 
 	devices := make([]*DeviceStatus, 0, len(s.devices))
 	for _, device := range s.devices {
-		devices = append(devices, device)
+		d := *device // shallow copy to avoid mutating stored data
+		if alias := s.getDisplayName(d.DeviceAddr); alias != "" {
+			d.DisplayName = alias
+		}
+		devices = append(devices, &d)
 	}
 	return devices
 }
@@ -1443,6 +1478,16 @@ func (s *Server) handleReadings(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// Inject display name if alias is set
+		s.mu.RLock()
+		alias := s.getDisplayName(deviceAddr)
+		s.mu.RUnlock()
+		if alias != "" {
+			for i := range readings {
+				readings[i].DisplayName = alias
+			}
+		}
+
 		respondJSON(w, readings)
 
 	default:
@@ -1507,9 +1552,13 @@ func (s *Server) handleDashboardData(w http.ResponseWriter, r *http.Request) {
 		ServerStartTime: s.startTime,
 	}
 
-	// Add devices
+	// Add devices with display names
 	for _, device := range s.devices {
-		dashboardData.Devices = append(dashboardData.Devices, device)
+		d := *device
+		if alias := s.getDisplayName(d.DeviceAddr); alias != "" {
+			d.DisplayName = alias
+		}
+		dashboardData.Devices = append(dashboardData.Devices, &d)
 	}
 
 	// Add clients and count active ones
@@ -1523,7 +1572,7 @@ func (s *Server) handleDashboardData(w http.ResponseWriter, r *http.Request) {
 	}
 	dashboardData.TotalReadings = totalReadings
 
-	// Add recent readings (last 10 for each device)
+	// Add recent readings (last 10 for each device) with display names
 	for addr, readings := range s.readings {
 		if len(readings) > 0 {
 			end := len(readings)
@@ -1531,7 +1580,19 @@ func (s *Server) handleDashboardData(w http.ResponseWriter, r *http.Request) {
 			if start < 0 {
 				start = 0
 			}
-			dashboardData.RecentReadings[addr] = readings[start:end]
+			alias := s.getDisplayName(addr)
+			slice := readings[start:end]
+			if alias != "" {
+				// Copy readings to inject display name without mutating stored data
+				copied := make([]Reading, len(slice))
+				copy(copied, slice)
+				for i := range copied {
+					copied[i].DisplayName = alias
+				}
+				dashboardData.RecentReadings[addr] = copied
+			} else {
+				dashboardData.RecentReadings[addr] = slice
+			}
 		}
 	}
 
@@ -1614,6 +1675,115 @@ func (s *Server) handleAPIKeys(w http.ResponseWriter, r *http.Request) {
 		} else {
 			s.mu.Unlock()
 			http.Error(w, "API key not found", http.StatusNotFound)
+		}
+
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// getDisplayName returns the alias for a device if set, otherwise empty string.
+// Caller must hold s.mu (read or write).
+func (s *Server) getDisplayName(deviceAddr string) string {
+	return s.deviceAliases[deviceAddr]
+}
+
+// handleDeviceAliases manages device friendly name aliases (admin only)
+func (s *Server) handleDeviceAliases(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		// List all aliases, or get a specific one
+		deviceAddr := r.URL.Query().Get("device")
+		s.mu.RLock()
+		if deviceAddr != "" {
+			alias, exists := s.deviceAliases[deviceAddr]
+			s.mu.RUnlock()
+			if !exists {
+				http.Error(w, "No alias set for device", http.StatusNotFound)
+				return
+			}
+			respondJSON(w, map[string]string{
+				"device_addr":  deviceAddr,
+				"display_name": alias,
+			})
+		} else {
+			// Return all aliases
+			aliases := make(map[string]string, len(s.deviceAliases))
+			for k, v := range s.deviceAliases {
+				aliases[k] = v
+			}
+			s.mu.RUnlock()
+			respondJSON(w, aliases)
+		}
+
+	case "PUT":
+		// Set or update an alias
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+
+		var req struct {
+			DeviceAddr  string `json:"device_addr"`
+			DisplayName string `json:"display_name"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		if req.DeviceAddr == "" {
+			http.Error(w, "device_addr is required", http.StatusBadRequest)
+			return
+		}
+
+		// Validate the display name using existing sanitization
+		if req.DisplayName == "" {
+			http.Error(w, "display_name is required", http.StatusBadRequest)
+			return
+		}
+		sanitized, err := sanitizeDeviceName(req.DisplayName)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Invalid display_name: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		s.mu.Lock()
+		s.deviceAliases[req.DeviceAddr] = sanitized
+		s.mu.Unlock()
+
+		if s.config.PersistenceEnabled {
+			s.saveData()
+		}
+
+		// Invalidate dashboard cache so the new name appears immediately
+		s.dashboardCache.Set(nil)
+
+		respondJSON(w, map[string]string{
+			"device_addr":  req.DeviceAddr,
+			"display_name": sanitized,
+		})
+
+	case "DELETE":
+		// Remove an alias
+		deviceAddr := r.URL.Query().Get("device")
+		if deviceAddr == "" {
+			http.Error(w, "Missing device parameter", http.StatusBadRequest)
+			return
+		}
+
+		s.mu.Lock()
+		if _, exists := s.deviceAliases[deviceAddr]; exists {
+			delete(s.deviceAliases, deviceAddr)
+			s.mu.Unlock()
+
+			if s.config.PersistenceEnabled {
+				s.saveData()
+			}
+
+			s.dashboardCache.Set(nil)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("Alias deleted"))
+		} else {
+			s.mu.Unlock()
+			http.Error(w, "No alias set for device", http.StatusNotFound)
 		}
 
 	default:
@@ -1855,6 +2025,7 @@ func main() {
 	mux.Handle("/stats", compressionMiddleware(securityMiddleware(rateLimitMiddleware(authMiddleware(http.HandlerFunc(server.handleStats))))))
 	mux.Handle("/dashboard/data", compressionMiddleware(securityMiddleware(rateLimitMiddleware(authMiddleware(http.HandlerFunc(server.handleDashboardData))))))
 	mux.Handle("/api/keys", compressionMiddleware(securityMiddleware(rateLimitMiddleware(authMiddleware(http.HandlerFunc(server.handleAPIKeys))))))
+	mux.Handle("/api/aliases", compressionMiddleware(securityMiddleware(rateLimitMiddleware(authMiddleware(http.HandlerFunc(server.handleDeviceAliases))))))
 	mux.Handle("/health", compressionMiddleware(securityMiddleware(rateLimitMiddleware(http.HandlerFunc(server.handleHealthCheck)))))
 
 	// Serve static files for dashboard (with security headers, but skip compression for pre-compressed assets)

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -158,7 +158,7 @@ const Dashboard = () => {
             <option value="">Select a device</option>
             {dashboardData?.devices.map((device) => (
               <option key={device.DeviceAddr} value={device.DeviceAddr}>
-                {device.DeviceName} ({device.DeviceAddr})
+                {device.display_name || device.DeviceName} ({device.DeviceAddr})
               </option>
             ))}
           </select>
@@ -166,6 +166,12 @@ const Dashboard = () => {
         
         {selectedDeviceObj && (
           <div>
+            {selectedDeviceObj.display_name && (
+              <div className="mb-4 pb-2 border-b">
+                <span className="text-lg font-semibold">{selectedDeviceObj.display_name}</span>
+                <span className="text-sm text-gray-500 ml-2">({selectedDeviceObj.DeviceName})</span>
+              </div>
+            )}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
               {/* Temperature */}
               <div className="bg-gray-50 p-4 rounded">


### PR DESCRIPTION
Allow users to assign human-readable names to devices via the server API. For example, device "GVH5075_8F19" can be aliased as "Kitchen Temperature" for easier identification across the system.

Server changes (govee-server.go):
- Add deviceAliases map (device_addr -> display_name) to Server struct
- Add /api/aliases endpoint (GET/PUT/DELETE) with auth middleware
- Inject display_name field into DeviceStatus and Reading responses at the response layer without mutating stored data
- Persist aliases to data/aliases.json alongside other server state
- Load aliases on startup from storage
- Invalidate dashboard cache when aliases change

API responses:
- GET /devices, GET /readings, GET /dashboard/data all include display_name field when an alias is set (omitted when not set)
- display_name uses existing sanitizeDeviceName validation

Dashboard (dashboard.js):
- Device selector dropdown shows alias when available
- Device detail section shows alias as header with hardware name in parentheses

Documentation:
- README.md: Add Device Aliases section with usage examples, add /api/aliases to endpoint table
- CLAUDE.md: Add alias endpoints to API listing
- openapi.yaml: Full /api/aliases path spec, display_name field added to Reading and DeviceStatus schemas

https://claude.ai/code/session_01XcvxnmTmpi6E2xErQ8yv5n